### PR TITLE
Define #to_msgpack to suitable Integer class for ruby-2.4.0

### DIFF
--- a/lib/msgpack_rails/activesupport/core_ext/object/to_msgpack.rb
+++ b/lib/msgpack_rails/activesupport/core_ext/object/to_msgpack.rb
@@ -8,7 +8,14 @@ end
 # The msgpack gem adds a few modules to Ruby core classes containing :to_msgpack definition, overwriting
 # their default behavior. That said, we need to define the basic to_msgpack method in all of them,
 # otherwise they will always use to_msgpack gem implementation.
-[Object, NilClass, TrueClass, FalseClass, Fixnum, Bignum, Float, String, Array, Hash, Symbol].each do |klass|
+classes = [Object, NilClass, TrueClass, FalseClass, Float, String, Array, Hash, Symbol]
+if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('2.4.0')
+  classes.push Integer
+else
+  classes.push Fixnum, Bignum
+end
+
+classes.each do |klass|
   klass.class_eval do
     alias_method :msgpack_to_msgpack, :to_msgpack if respond_to?(:to_msgpack)
     # Dumps object in msgpack. See http://msgpack.org for more infoa


### PR DESCRIPTION
Starting with Ruby 2.4, Fixnum and Bignum are unified into Integer.

See:
http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html
